### PR TITLE
Fix for stack size limitation

### DIFF
--- a/src/shared/sitemap.mjs
+++ b/src/shared/sitemap.mjs
@@ -2,7 +2,9 @@ import Sitemapper from "sitemapper";
 import { fetchRetry } from "./utils.mjs";
 
 async function getSitemapsList(accessToken, siteUrl) {
-  const url = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(siteUrl)}/sitemaps`;
+  const url = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(
+    siteUrl
+  )}/sitemaps`;
 
   const response = await fetchRetry(url, {
     headers: {
@@ -30,14 +32,14 @@ async function getSitemapsList(accessToken, siteUrl) {
 export async function getSitemapPages(accessToken, siteUrl) {
   const sitemaps = await getSitemapsList(accessToken, siteUrl);
 
-  const pages = [];
+  let pages = [];
   for (const url of sitemaps) {
     const Google = new Sitemapper({
       url,
     });
 
     const { sites } = await Google.fetch();
-    pages.push(...sites);
+    pages = [...pages, ...sites];
   }
 
   return [sitemaps, [...new Set(pages)]];


### PR DESCRIPTION
If there are a large number of URLs (1.8M in my case 😅️), the spread operator can cause a stack size limit exceeded error when building the array of URLs.

This PR fixes this using the approach in this [SO answer](https://stackoverflow.com/questions/61740599/rangeerror-maximum-call-stack-size-exceeded-with-array-push)