### PR TITLE
Adds `Not found (404)` to `indexableStatuses`

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -43,6 +43,7 @@ const indexableStatuses = [
   "URL is unknown to Google",
   "Forbidden",
   "Error",
+  "Not found (404)"
 ];
 
 const shouldRecheck = (status, lastCheckedAt) => {


### PR DESCRIPTION
This PR adds `Not Found (404)` to the list of `indexableStatuses`. 
This change ensures that pages returning a 404 status are correctly recognized and processed within the script's indexing logic, enhancing the accuracy of indexing operations for sites with varying page statuses.

Please let me know if you have feedback.