### PR TITLE
Change cachePath string declaration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,7 @@ export const index = async (
   const accessToken = await getAccessToken(options.client_email, options.private_key, options.path);
   let siteUrl = convertToSiteUrl(input);
   console.log(`🔎 Processing site: ${siteUrl}`);
-  const cacheFileName = `${convertToFilePath(siteUrl)}`+".json";
-  const cachePath = path.join(".cache", cacheFileName.replace("/", ""));
+  const cachePath = path.join(".cache", `${convertToFilePath(siteUrl)}.json`);
 
   if (!accessToken) {
     console.error("❌ Failed to get access token, check your service account credentials.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,8 @@ export const index = async (
   const accessToken = await getAccessToken(options.client_email, options.private_key, options.path);
   let siteUrl = convertToSiteUrl(input);
   console.log(`🔎 Processing site: ${siteUrl}`);
-  const cachePath = path.join(".cache", `${convertToFilePath(siteUrl)}.json`);
+  const cacheFileName = `${convertToFilePath(siteUrl)}`+".json";
+  const cachePath = path.join(".cache", cacheFileName.replace("/", ""));
 
   if (!accessToken) {
     console.error("❌ Failed to get access token, check your service account credentials.");

--- a/src/shared/gsc.ts
+++ b/src/shared/gsc.ts
@@ -20,7 +20,7 @@ export function convertToSiteUrl(input: string) {
  * @returns The converted file path
  */
 export function convertToFilePath(path: string) {
-  return path.replace("http://", "http_").replace("https://", "https_").replace("/", "_");
+  return path.replace("http://", "http_").replace("https://", "https_").replaceAll("/", "_");
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
-    "lib": ["dom", "es6", "es2017", "esnext.asynciterable"],
+    "lib": ["dom", "es6", "es2021", "esnext.asynciterable"],
     "skipLibCheck": true,
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
**What did I change?**

Fixed a bug that prevented the use of the script when a url was sent. #49 

When trying to send a url, the script gave an error when trying to write the cache file.

This is an example with my own website
`
./google-indexing-script/.cache/https_teenbiscuits.github.io_Pro2324/.json
`

Now this is the new output
`
./google-indexing-script/.cache/https_teenbiscuits.github.io_Pro2324.json
`

Now when converting from url to path and adding the .json ending, the residual "/" is also removed.

I'm a bit new to js so this is an easy patch for my use case.