### PR TITLE
chore(release): version bump to 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # google-indexing-script
 
+## 0.0.6
+
+### Patch Changes
+
+- [#53](https://github.com/goenning/google-indexing-script/pull/53) [`621444c`](https://github.com/goenning/google-indexing-script/commit/621444cc57d9cff1cc5333747c848746fdffeb52) Thanks [@urbanisierung](https://github.com/urbanisierung)! - feat(get-publish-metadata): optional retries if rate limited
+
 ## 0.0.5
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-indexing-script",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
**What did I change?**

* Version bump to `0.0.6`
* Update changelog

**Why did I change it?**

* Last release workflow failed because of version conflict.