### PR TITLE
fix: Improve caching mechanism for URL indexing status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "google-indexing-script",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "google-indexing-script",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,4 +11,5 @@ export enum Status {
   RateLimited = "RateLimited",
   Forbidden = "Forbidden",
   Error = "Error",
+  NotFound = "Not found (404)",
 }


### PR DESCRIPTION

**What did I change?**

- Modify shouldRecheck function to always process non-indexed URLs
- Ensure "Submitted and Indexed" URLs are only rechecked after cache timeout
- Optimize batch processing to avoid unnecessary API calls

**Why did I change it?**

Every run on the script was trying the process the same urls and then timing out. 
Related: https://github.com/goenning/google-indexing-script/issues/51 https://github.com/goenning/google-indexing-script/pull/59
