### PR TITLE
do not run process.exit(1) on error, instead throw js error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "google-indexing-script",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "google-indexing-script",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,12 +37,11 @@ export type IndexOptions = {
  * Indexes the specified domain or site URL.
  * @param input - The domain or site URL to index.
  * @param options - (Optional) Additional options for indexing.
+ * @throws Error if there are issues with input parameters or API operations
  */
 export const index = async (input: string = process.argv[2], options: IndexOptions = {}) => {
   if (!input) {
-    console.error("❌ Please provide a domain or site URL as the first argument.");
-    console.error("");
-    process.exit(1);
+    throw new Error("Please provide a domain or site URL as the first argument.");
   }
 
   if (!options.client_email) {
@@ -69,9 +68,7 @@ export const index = async (input: string = process.argv[2], options: IndexOptio
   const cachePath = path.join(".cache", `${convertToFilePath(siteUrl)}.json`);
 
   if (!accessToken) {
-    console.error("❌ Failed to get access token, check your service account credentials.");
-    console.error("");
-    process.exit(1);
+    throw new Error("Failed to get access token, check your service account credentials.");
   }
 
   siteUrl = await checkSiteUrl(accessToken, siteUrl);
@@ -82,9 +79,7 @@ export const index = async (input: string = process.argv[2], options: IndexOptio
     const [sitemaps, pagesFromSitemaps] = await getSitemapPages(accessToken, siteUrl);
 
     if (sitemaps.length === 0) {
-      console.error("❌ No sitemaps found, add them to Google Search Console and try again.");
-      console.error("");
-      process.exit(1);
+      throw new Error("No sitemaps found, add them to Google Search Console and try again.");
     }
 
     pages = pagesFromSitemaps;

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -9,6 +9,7 @@ import os from "os";
  * @param private_key - The private key of the service account.
  * @param customPath - (Optional) Custom path to the service account JSON file.
  * @returns The access token.
+ * @throws Error if credentials are missing or invalid
  */
 export async function getAccessToken(client_email?: string, private_key?: string, customPath?: string) {
   if (!client_email && !private_key) {
@@ -19,9 +20,7 @@ export async function getAccessToken(client_email?: string, private_key?: string
     const isCustomFile = !!customPath && fs.existsSync(customPath);
 
     if (!isFile && !isFileFromHome && !isCustomFile) {
-      console.error(`❌ ${filePath} not found, please follow the instructions in README.md`);
-      console.error("");
-      process.exit(1);
+      throw new Error(`${filePath} not found, please follow the instructions in README.md`);
     }
 
     const key = JSON.parse(
@@ -31,15 +30,11 @@ export async function getAccessToken(client_email?: string, private_key?: string
     private_key = key.private_key;
   } else {
     if (!client_email) {
-      console.error("❌ Missing client_email in service account credentials.");
-      console.error("");
-      process.exit(1);
+      throw new Error("Missing client_email in service account credentials.");
     }
 
     if (!private_key) {
-      console.error("❌ Missing private_key in service account credentials.");
-      console.error("");
-      process.exit(1);
+      throw new Error("Missing private_key in service account credentials.");
     }
   }
 


### PR DESCRIPTION
Replacing `process.exit(1)` with normal JS errors